### PR TITLE
Add GOV.UK CSP Forwarder

### DIFF
--- a/uses.md
+++ b/uses.md
@@ -28,3 +28,8 @@
 - GOV.UK Verify
 - A spike into running a Ruby on Rails lambda
 - https://github.com/alphagov/rails-lambda-spike
+
+11. **GOV.UK CSP Forwarder**
+- GOV.UK
+- Used to collect content security policy violation reports from GOV.UK pages, filter them and forward them to Sentry for logging
+- https://github.com/alphagov/govuk-csp-forwarder


### PR DESCRIPTION
Merge after https://github.com/alphagov/gds-faas/pull/3 and https://github.com/alphagov/gds-faas/pull/4 for consistent numbering.